### PR TITLE
rmmod in correct order

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-sudo rmmod nvidia nvidia_uvm nvidia_modeset nvidia_drm
-sudo rmmod nvidia nvidia_uvm nvidia_modeset nvidia_drm
-sudo rmmod nvidia nvidia_uvm nvidia_modeset nvidia_drm
-sudo rmmod nvidia nvidia_uvm nvidia_modeset nvidia_drm
+sudo rmmod nvidia_drm nvidia_modeset nvidia_uvm nvidia
 set -e
 make modules -j$(nproc)
 sudo make modules_install -j$(nproc)


### PR DESCRIPTION
When removed in the correct order all kernel modules are successfully removed in one shot (and with no errors).

If something is using one of the modules it will never get unloaded on it's own, so I can't see a reason to have multiple `rmmod` calls.