### PR TITLE
Fix error for nvidia_* is in use

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# Detach users for 
+# rmmod: ERROR: Module nvidia_drm nvidia_uvm is in use
+sudo systemctl isolate multi-user.target
+#
 sudo rmmod nvidia_drm nvidia_modeset nvidia_uvm nvidia
 set -e
 make modules -j$(nproc)


### PR DESCRIPTION
Fixing 

rmmod: ERROR: Module nvidia_drm is in use
rmmod: ERROR: Module nvidia_modeset is in use by: nvidia_drm
rmmod: ERROR: Module nvidia_uvm is in use
rmmod: ERROR: Module nvidia is in use by: nvidia_uvm nvidia_modeset